### PR TITLE
Enhance: Add the flexibility of pre-buffer

### DIFF
--- a/FLAnimatedImage/FLAnimatedImage+GIF.m
+++ b/FLAnimatedImage/FLAnimatedImage+GIF.m
@@ -145,7 +145,7 @@
                                       frameCount:frameCount
                                skippedFrameCount:skippedFrameCount
                             delayTimesForIndexes:delayTimesForIndexesMutable
-                        preferFrameCacheStrategy:FLAnimatedImagePreferFrameCacheStrategyDefault
+                        preferFrameCacheStrategy:FLAnimatedImagePreferredFrameCacheStrategyDataSizeOptimized
                                      posterImage:posterImage
                                 posterImageIndex:posterImageFrameIndex
                                  frameDataSource:dataSource];

--- a/FLAnimatedImage/FLAnimatedImage+GIF.m
+++ b/FLAnimatedImage/FLAnimatedImage+GIF.m
@@ -145,7 +145,7 @@
                                       frameCount:frameCount
                                skippedFrameCount:skippedFrameCount
                             delayTimesForIndexes:delayTimesForIndexesMutable
-                        preferFrameCacheStrategy:FLAnimatedImagePreferredFrameCacheStrategyDataSizeOptimized
+                        preferFrameCacheStrategy:FLAnimatedImagePreferredFrameCacheStrategyOptimizedForTotalFrames
                                      posterImage:posterImage
                                 posterImageIndex:posterImageFrameIndex
                                  frameDataSource:dataSource];

--- a/FLAnimatedImage/FLAnimatedImage+GIF.m
+++ b/FLAnimatedImage/FLAnimatedImage+GIF.m
@@ -145,6 +145,7 @@
                                       frameCount:frameCount
                                skippedFrameCount:skippedFrameCount
                             delayTimesForIndexes:delayTimesForIndexesMutable
+                        preferFrameCacheStrategy:FLAnimatedImagePreferFrameCacheStrategyDefault
                                      posterImage:posterImage
                                 posterImageIndex:posterImageFrameIndex
                                  frameDataSource:dataSource];

--- a/FLAnimatedImage/FLAnimatedImage+WebP.m
+++ b/FLAnimatedImage/FLAnimatedImage+WebP.m
@@ -98,7 +98,7 @@
                                       frameCount:frameCount
                                skippedFrameCount:skippedFrameCount
                             delayTimesForIndexes:delayTimesForIndexesMutable
-                        preferFrameCacheStrategy:FLAnimatedImagePreferFrameCacheStrategyBest
+                        preferFrameCacheStrategy:FLAnimatedImagePreferredFrameCacheStrategyBest
                                      posterImage:posterImage
                                 posterImageIndex:posterImageFrameIndex
                                  frameDataSource:dataSource];
@@ -134,7 +134,7 @@
                                                          frameCount:decoder.frameCount
                                                   skippedFrameCount:skippedFrameCount
                                                delayTimesForIndexes:delayTimesForIndexesMutable
-                                           preferFrameCacheStrategy:FLAnimatedImagePreferFrameCacheStrategyBest
+                                           preferFrameCacheStrategy:FLAnimatedImagePreferredFrameCacheStrategyBest
                                                         posterImage:posterImage
                                                    posterImageIndex:posterImageFrameIndex
                                                     frameDataSource:dataSource];

--- a/FLAnimatedImage/FLAnimatedImage+WebP.m
+++ b/FLAnimatedImage/FLAnimatedImage+WebP.m
@@ -98,7 +98,7 @@
                                       frameCount:frameCount
                                skippedFrameCount:skippedFrameCount
                             delayTimesForIndexes:delayTimesForIndexesMutable
-                        preferFrameCacheStrategy:FLAnimatedImagePreferredFrameCacheStrategyBest
+                        preferFrameCacheStrategy:FLAnimatedImagePreferredFrameCacheStrategyDefault
                                      posterImage:posterImage
                                 posterImageIndex:posterImageFrameIndex
                                  frameDataSource:dataSource];
@@ -134,7 +134,7 @@
                                                          frameCount:decoder.frameCount
                                                   skippedFrameCount:skippedFrameCount
                                                delayTimesForIndexes:delayTimesForIndexesMutable
-                                           preferFrameCacheStrategy:FLAnimatedImagePreferredFrameCacheStrategyBest
+                                           preferFrameCacheStrategy:FLAnimatedImagePreferredFrameCacheStrategyDefault
                                                         posterImage:posterImage
                                                    posterImageIndex:posterImageFrameIndex
                                                     frameDataSource:dataSource];

--- a/FLAnimatedImage/FLAnimatedImage+WebP.m
+++ b/FLAnimatedImage/FLAnimatedImage+WebP.m
@@ -98,6 +98,7 @@
                                       frameCount:frameCount
                                skippedFrameCount:skippedFrameCount
                             delayTimesForIndexes:delayTimesForIndexesMutable
+                        preferFrameCacheStrategy:FLAnimatedImagePreferFrameCacheStrategyBest
                                      posterImage:posterImage
                                 posterImageIndex:posterImageFrameIndex
                                  frameDataSource:dataSource];
@@ -133,6 +134,7 @@
                                                          frameCount:decoder.frameCount
                                                   skippedFrameCount:skippedFrameCount
                                                delayTimesForIndexes:delayTimesForIndexesMutable
+                                           preferFrameCacheStrategy:FLAnimatedImagePreferFrameCacheStrategyBest
                                                         posterImage:posterImage
                                                    posterImageIndex:posterImageFrameIndex
                                                     frameDataSource:dataSource];

--- a/FLAnimatedImage/FLAnimatedImage.m
+++ b/FLAnimatedImage/FLAnimatedImage.m
@@ -167,15 +167,17 @@ static NSHashTable *allAnimatedImagesWeak;
                   frameCount:(NSUInteger)frameCount
            skippedFrameCount:(NSUInteger)skippedFrameCount
         delayTimesForIndexes:(NSDictionary *)delayTimesForIndexes
+    preferFrameCacheStrategy:(FLAnimatedImagePreferFrameCacheStrategy)strategy
                  posterImage:(UIImage *)posterImage
             posterImageIndex:(NSUInteger)posterImageIndex
-             frameDataSource:(id<FLAnimatedImageFrameDataSource>)frameDataSource
+             frameDataSource:(id<FLAnimatedImageFrameDataSource>)frameDataSource;
 {
     if (self = [super init]) {
         _frameDataSource = frameDataSource;
         _frameCache = [[FLAnimatedImageFrameCache alloc] initWithFrameCount:frameCount
                                                           skippedFrameCount:skippedFrameCount
                                                                   frameSize:CGImageGetBytesPerRow(posterImage.CGImage) * size.height
+                                                   preferFrameCacheStrategy:strategy
                                                                 posterImage:posterImage
                                                            posterImageIndex:posterImageIndex
                                                                  dataSource:frameDataSource];

--- a/FLAnimatedImage/FLAnimatedImage.m
+++ b/FLAnimatedImage/FLAnimatedImage.m
@@ -44,7 +44,7 @@ typedef NS_ENUM(NSUInteger, FLAnimatedImageFrameCacheSize) {
     FLAnimatedImageFrameCacheSizeNoLimit = 0,                // 0 means no specific limit
     FLAnimatedImageFrameCacheSizeLowMemory = 1,              // The minimum frame cache size; this will produce frames on-demand.
     FLAnimatedImageFrameCacheSizeGrowAfterMemoryWarning = 2, // If we can produce the frames faster than we consume, one frame ahead will already result in a stutter-free playback.
-    FLAnimatedImageFrameCacheSizeDefault = 5                 // Build up a comfy buffer window to cope with CPU hiccups etc.
+    FLAnimatedImageFrameCacheSizeBest = 5                 // Build up a comfy buffer window to cope with CPU hiccups etc.
 };
 
 @protocol FLAnimatedImageViewDebugDelegate;
@@ -167,7 +167,7 @@ static NSHashTable *allAnimatedImagesWeak;
                   frameCount:(NSUInteger)frameCount
            skippedFrameCount:(NSUInteger)skippedFrameCount
         delayTimesForIndexes:(NSDictionary *)delayTimesForIndexes
-    preferFrameCacheStrategy:(FLAnimatedImagePreferFrameCacheStrategy)strategy
+    preferFrameCacheStrategy:(FLAnimatedImagePreferredFrameCacheStrategy)strategy
                  posterImage:(UIImage *)posterImage
             posterImageIndex:(NSUInteger)posterImageIndex
              frameDataSource:(id<FLAnimatedImageFrameDataSource>)frameDataSource;

--- a/FLAnimatedImage/FLAnimatedImageFrameCache.m
+++ b/FLAnimatedImage/FLAnimatedImageFrameCache.m
@@ -129,10 +129,10 @@ static NSHashTable *allAnimatedImagesWeak;
 
         CGFloat animatedImageDataSize = frameSize * (_frameCount - skippedFrameCount) / MEGABYTE;
         switch (strategy) {
-            case FLAnimatedImagePreferredFrameCacheStrategyBest:
+            case FLAnimatedImagePreferredFrameCacheStrategyDefault:
                 _frameCacheSizeOptimal = FLAnimatedImageFrameCacheSizeBest;
                 break;
-            case FLAnimatedImagePreferredFrameCacheStrategyDataSizeOptimized:
+            case FLAnimatedImagePreferredFrameCacheStrategyOptimizedForTotalFrames:
                 if (animatedImageDataSize <= FLAnimatedImageDataSizeCategoryAll) {
                     _frameCacheSizeOptimal = _frameCount;
                 } else if (animatedImageDataSize <= FLAnimatedImageDataSizeCategoryDefault) {

--- a/FLAnimatedImage/FLAnimatedWebPDataSource.m
+++ b/FLAnimatedImage/FLAnimatedWebPDataSource.m
@@ -132,7 +132,7 @@
     }
 
     _blendedImageDict[@(index)] = image;
-//     Drawing the blended image failed, fallback to `image`
+    // Drawing the blended image failed, fallback to `image`
     return image;
 }
 

--- a/FLAnimatedImage/include/FLAnimatedImage+Internal.h
+++ b/FLAnimatedImage/include/FLAnimatedImage+Internal.h
@@ -7,6 +7,7 @@
 //
 
 #import "FLAnimatedImage.h"
+#import "FLAnimatedImageFrameCache.h"
 
 @interface FLAnimatedImage (Internal)
 
@@ -16,10 +17,10 @@
                   frameCount:(NSUInteger)frameCount
            skippedFrameCount:(NSUInteger)skippedFrameCount
         delayTimesForIndexes:(NSDictionary *)delayTimesForIndexes
+    preferFrameCacheStrategy:(FLAnimatedImagePreferFrameCacheStrategy)strategy
                  posterImage:(UIImage *)posterImage
             posterImageIndex:(NSUInteger)posterImageIndex
              frameDataSource:(id<FLAnimatedImageFrameDataSource>)frameDataSource;
-
 @end
 
 // If a frame has a delay time less than kDelayTimeIntervalMinimum, we instead use kDelayTimeIntervalDefault as the

--- a/FLAnimatedImage/include/FLAnimatedImage+Internal.h
+++ b/FLAnimatedImage/include/FLAnimatedImage+Internal.h
@@ -17,7 +17,7 @@
                   frameCount:(NSUInteger)frameCount
            skippedFrameCount:(NSUInteger)skippedFrameCount
         delayTimesForIndexes:(NSDictionary *)delayTimesForIndexes
-    preferFrameCacheStrategy:(FLAnimatedImagePreferFrameCacheStrategy)strategy
+    preferFrameCacheStrategy:(FLAnimatedImagePreferredFrameCacheStrategy)strategy
                  posterImage:(UIImage *)posterImage
             posterImageIndex:(NSUInteger)posterImageIndex
              frameDataSource:(id<FLAnimatedImageFrameDataSource>)frameDataSource;

--- a/FLAnimatedImage/include/FLAnimatedImageFrameCache.h
+++ b/FLAnimatedImage/include/FLAnimatedImageFrameCache.h
@@ -14,9 +14,9 @@
 @protocol FLAnimatedImageDebugDelegate;
 #endif
 
-typedef NS_ENUM(NSUInteger, FLAnimatedImagePreferFrameCacheStrategy) {
-    FLAnimatedImagePreferFrameCacheStrategyBest,
-    FLAnimatedImagePreferFrameCacheStrategyDefault
+typedef NS_ENUM(NSUInteger, FLAnimatedImagePreferredFrameCacheStrategy) {
+    FLAnimatedImagePreferredFrameCacheStrategyBest,   // Set the frame cache size to 5
+    FLAnimatedImagePreferredFrameCacheStrategyDataSizeOptimized // Set the frame cache size according to the total frames
 };
 
 @interface FLAnimatedImageFrameCache : NSObject
@@ -35,7 +35,7 @@ typedef NS_ENUM(NSUInteger, FLAnimatedImagePreferFrameCacheStrategy) {
 - (instancetype)initWithFrameCount:(NSUInteger)frameCount
                  skippedFrameCount:(NSUInteger)skippedFrameCount
                          frameSize:(CGFloat)frameSize
-          preferFrameCacheStrategy:(FLAnimatedImagePreferFrameCacheStrategy)strategy
+          preferFrameCacheStrategy:(FLAnimatedImagePreferredFrameCacheStrategy)strategy
                        posterImage:(UIImage *)posterImage
                   posterImageIndex:(NSUInteger)posterImageIndex
                         dataSource:(id<FLAnimatedImageFrameDataSource>)dataSource;

--- a/FLAnimatedImage/include/FLAnimatedImageFrameCache.h
+++ b/FLAnimatedImage/include/FLAnimatedImageFrameCache.h
@@ -15,8 +15,8 @@
 #endif
 
 typedef NS_ENUM(NSUInteger, FLAnimatedImagePreferredFrameCacheStrategy) {
-    FLAnimatedImagePreferredFrameCacheStrategyBest,   // Set the frame cache size to 5
-    FLAnimatedImagePreferredFrameCacheStrategyDataSizeOptimized // Set the frame cache size according to the total frames
+    FLAnimatedImagePreferredFrameCacheStrategyDefault,   // Set the frame cache size to 5
+    FLAnimatedImagePreferredFrameCacheStrategyOptimizedForTotalFrames // Set the frame cache size according to the total frames
 };
 
 @interface FLAnimatedImageFrameCache : NSObject

--- a/FLAnimatedImage/include/FLAnimatedImageFrameCache.h
+++ b/FLAnimatedImage/include/FLAnimatedImageFrameCache.h
@@ -14,6 +14,11 @@
 @protocol FLAnimatedImageDebugDelegate;
 #endif
 
+typedef NS_ENUM(NSUInteger, FLAnimatedImagePreferFrameCacheStrategy) {
+    FLAnimatedImagePreferFrameCacheStrategyBest,
+    FLAnimatedImagePreferFrameCacheStrategyDefault
+};
+
 @interface FLAnimatedImageFrameCache : NSObject
 
 /**
@@ -26,9 +31,11 @@
  * posterImage - a static representation of the animated image, typically the first frame of the image.
  * posterImageIndex - the index of the poster image frame.
  */
+
 - (instancetype)initWithFrameCount:(NSUInteger)frameCount
                  skippedFrameCount:(NSUInteger)skippedFrameCount
                          frameSize:(CGFloat)frameSize
+          preferFrameCacheStrategy:(FLAnimatedImagePreferFrameCacheStrategy)strategy
                        posterImage:(UIImage *)posterImage
                   posterImageIndex:(NSUInteger)posterImageIndex
                         dataSource:(id<FLAnimatedImageFrameDataSource>)dataSource;

--- a/FLAnimatedImageDemo/RootViewController.m
+++ b/FLAnimatedImageDemo/RootViewController.m
@@ -90,7 +90,7 @@
     self.imageView2.frame = CGRectMake(0.0, 577.0, 379.0, 447.0);
     
 
-    NSURL *url2 = [NSURL URLWithString:@"https://picola-asset.piccollage.com/expires_in_days/7/imageassets/public_e0d4d366d4d2256ab6671c4bfb676cc9/800x800.webp?revision=1682413820"];//@"https://colinbendell.github.io/webperf/animated-gif-decode/2.webp"];//@"https://picola-asset.piccollage.com/expires_in_days/7/imageassets/public_e0d4d366d4d2256ab6671c4bfb676cc9/800x800.webp"];
+    NSURL *url2 = [NSURL URLWithString:@"https://colinbendell.github.io/webperf/animated-gif-decode/2.webp"];
 
     [self loadAnimatedImageWithURL:url2 completion:^(FLAnimatedImage *animatedImage) {
         self.imageView2.animatedImage = animatedImage;

--- a/FLAnimatedImageDemo/RootViewController.m
+++ b/FLAnimatedImageDemo/RootViewController.m
@@ -79,7 +79,7 @@
     NSData *data1 = [NSData dataWithContentsOfURL:url1];
     FLAnimatedImage *animatedImage1 = [FLAnimatedImage animatedImageWithData:data1];
     self.imageView1.animatedImage = animatedImage1;
-    
+
     // 2
     if (!self.imageView2) {
         self.imageView2 = [[FLAnimatedImageView alloc] init];
@@ -90,7 +90,7 @@
     self.imageView2.frame = CGRectMake(0.0, 577.0, 379.0, 447.0);
     
 
-    NSURL *url2 = [NSURL URLWithString:@"https://colinbendell.github.io/webperf/animated-gif-decode/2.webp"];//@"https://picola-asset.piccollage.com/expires_in_days/7/imageassets/public_e0d4d366d4d2256ab6671c4bfb676cc9/800x800.webp"];
+    NSURL *url2 = [NSURL URLWithString:@"https://picola-asset.piccollage.com/expires_in_days/7/imageassets/public_e0d4d366d4d2256ab6671c4bfb676cc9/800x800.webp?revision=1682413820"];//@"https://colinbendell.github.io/webperf/animated-gif-decode/2.webp"];//@"https://picola-asset.piccollage.com/expires_in_days/7/imageassets/public_e0d4d366d4d2256ab6671c4bfb676cc9/800x800.webp"];
 
     [self loadAnimatedImageWithURL:url2 completion:^(FLAnimatedImage *animatedImage) {
         self.imageView2.animatedImage = animatedImage;


### PR DESCRIPTION
FLAnimatedImage has its own strategy of the pre-buffer size but it doesn't quite fit to our needs. 
I add two options to the pre-buffer setting. One is for `default`, the behavior remains the same as the original one as it decides the frame buffer size according to the total frames. The other option `best` would set pre-buffer to the size `FLAnimatedImageFrameCacheSizeDefault` which is 5.