### PR TITLE
:bug: Add the images that don't required to be blended to cache

### DIFF
--- a/FLAnimatedImage/FLAnimatedWebPDataSource.m
+++ b/FLAnimatedImage/FLAnimatedWebPDataSource.m
@@ -21,7 +21,7 @@
     NSData *_data;
 
     CGRect _imageRect;
-    NSMutableDictionary<NSNumber *, UIImage *> *_blendedImageDict;
+    NSMutableDictionary<NSNumber *, UIImage *> *_processedImageDict;
 }
 
 - (instancetype)initWithWebPDemuxer:(FLAnimatedWebPDemuxer *)demuxer frameInfo:(NSArray *)frameInfo
@@ -30,7 +30,7 @@
     if (self) {
         _demuxer = demuxer;
         _frameInfo = [frameInfo copy];
-        _blendedImageDict = [[NSMutableDictionary alloc] init];
+        _processedImageDict = [[NSMutableDictionary alloc] init];
 
         int pixelHeight = WebPDemuxGetI(_demuxer.demuxer, WEBP_FF_CANVAS_HEIGHT);
         int pixelWidth = WebPDemuxGetI(_demuxer.demuxer, WEBP_FF_CANVAS_WIDTH);
@@ -42,8 +42,8 @@
 - (UIImage *)imageAtIndex:(NSUInteger)index
 {
     // Use blended images if it has already been created
-    if (_blendedImageDict[@(index)]) {
-        return _blendedImageDict[@(index)];
+    if (_processedImageDict[@(index)]) {
+        return _processedImageDict[@(index)];
     }
 
     WebPIterator iterator;
@@ -57,6 +57,12 @@
         image = [UIImage imageWithCGImage:imageRef];
         CGImageRelease(imageRef);
         image = [UIImage predrawnImageFromImage:image];
+
+        // images that don't require to be blended should add to cache as well
+        // for the images that require to be blended will add to cached after being blended in `blendImage:atIndex:withPreviousImage:`
+        if ([self frameRequiresBlendingWithPreviousFrame:index] == NO) {
+            _processedImageDict[@(index)] = image;
+        }
     }
 
     WebPDemuxReleaseIterator(&iterator);
@@ -97,8 +103,8 @@
 
 - (UIImage *)blendImage:(UIImage *)image atIndex:(NSUInteger)index withPreviousImage:(UIImage *)previousImage
 {
-    if (_blendedImageDict[@(index)]) {
-        return _blendedImageDict[@(index)];
+    if (_processedImageDict[@(index)]) {
+        return _processedImageDict[@(index)];
     }
 
     FLAnimatedWebPFrameInfo *previousFrameInfo = _frameInfo[index - 1];
@@ -127,11 +133,11 @@
     if (newCGImage) {
         UIImage *newImage = [UIImage imageWithCGImage:newCGImage];
         CGImageRelease(newCGImage);
-        _blendedImageDict[@(index)] = newImage;
+        _processedImageDict[@(index)] = newImage;
         return newImage;
     }
 
-    _blendedImageDict[@(index)] = image;
+    _processedImageDict[@(index)] = image;
     // Drawing the blended image failed, fallback to `image`
     return image;
 }


### PR DESCRIPTION
Previously, we only add the images that require blending with other image to the cache. 
And didn't consider the case for those blending free image. In this PR, we add those images that are not required to blend to cache as well.