### PR TITLE
build: add module.modulemap

### DIFF
--- a/FLAnimatedImage/include/module.modulemap
+++ b/FLAnimatedImage/include/module.modulemap
@@ -1,0 +1,6 @@
+module FLAnimatedImage {
+    umbrella header "FLAnimatedImage.h"
+
+    export *
+    module * { export * }
+}


### PR DESCRIPTION
# Description

build: add module.modulemap

See this error on CircleCI

<img width="1347" alt="image" src="https://github.com/user-attachments/assets/1e9738f4-b01e-4532-87c5-124ff13f9d66" />

# Screenshots

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

... add the demo screenshots or videos here ...

</td>
<td>

... add the demo screenshots or videos here ...

</td>
</tr>
</table>